### PR TITLE
Allow custom `HOST_SWIFT_TOOLCHAIN`, `HOST_X_LDD`, and `INSTALL_PREFIX`

### DIFF
--- a/amazonlinux2/Makefile
+++ b/amazonlinux2/Makefile
@@ -34,7 +34,10 @@ PLATFORM=amazonlinux2
 PACKAGE_URL=https://swift.org/builds/$(BRANCH)/$(subst .,,$(PLATFORM))/swift-$(TARBALL_VERSION)-$(SNAPSHOT)/swift-$(TARBALL_VERSION)-$(SNAPSHOT)-$(PLATFORM).tar.gz
 
 HOST_SWIFT_TOOLCHAIN=/usr/local/lib/swift/xctoolchains/$(ARCH)-apple-darwin/$(HOST_VERSION)-current/swift.xctoolchain
+HOST_X_LLD=$(SWIFT_LIB_DIR)/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld
 
+
+INSTALL_PREFIX=$(BUILD_DIR)
 
 BUILD_DIR=$(PWD)/.build
 FETCH_DIR=$(PWD)/.fetch
@@ -148,6 +151,8 @@ build-toolchain: $(PACKAGE_FETCH_FILE)
 	HOST_SWIFT_TOOLCHAIN=$(HOST_SWIFT_TOOLCHAIN)	\
 	TARGET_ARCH=$(ARCH)				\
 	TARGET_PLATFORM=$(PLATFORM)			\
+	HOST_X_LLD=$(HOST_X_LLD) \
+	INSTALL_PREFIX=$(INSTALL_PREFIX) \
 	./build-toolchain.sh $(PWD)/.fetch/swift-$(VERSION)-$(PLATFORM).tar.gz
 
 

--- a/amazonlinux2/build-toolchain.sh
+++ b/amazonlinux2/build-toolchain.sh
@@ -27,7 +27,7 @@ SWIFT_LIB_DIR=${SWIFT_LIB_DIR:=/usr/local/lib/swift}
 # brew install swiftxcode/swiftxcode/clang-llvm-bin-8
 # ./retrieve-sdk-packages.sh
 HOST_SWIFT_TOOLCHAIN=${HOST_SWIFT_TOOLCHAIN:=${SWIFT_LIB_DIR}/xctoolchains/${HOST_PLATFORM}-apple-darwin/${SWIFT_VERSION}-current/swift.xctoolchain}
-HOST_X_LLD=${SWIFT_LIB_DIR}/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld
+HOST_X_LLD=${HOST_X_LLD:=${SWIFT_LIB_DIR}/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld}
 linux_sdk_name="${TARGET_ARCH}-${TARGET_PLATFORM}.sdk"
 LINUX_SDK="${BUILD_DIR}/${linux_sdk_name}"
 

--- a/ubuntu16.04/Makefile
+++ b/ubuntu16.04/Makefile
@@ -25,6 +25,11 @@ LINUX_TARGET_TRIPLE=$(ARCH)-linux-gnu
 PLATFORM=ubuntu16.04
 PACKAGE_URL=https://swift.org/builds/$(BRANCH)/$(subst .,,$(PLATFORM))/swift-$(VERSION)-$(SNAPSHOT)/swift-$(VERSION)-$(SNAPSHOT)-$(PLATFORM).tar.gz
 
+HOST_SWIFT_TOOLCHAIN=/usr/local/lib/swift/xctoolchains/$(ARCH)-apple-darwin/$(HOST_VERSION)-current/swift.xctoolchain
+HOST_X_LLD=$(SWIFT_LIB_DIR)/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld
+
+INSTALL_PREFIX=$(BUILD_DIR)
+
 BUILD_DIR=$(PWD)/.build
 FETCH_DIR=$(PWD)/.fetch
 PATCH_DIR=$(BUILD_DIR)/patch
@@ -109,7 +114,13 @@ retrieve-packages:
 # toolchain builder
 
 build-toolchain: $(PACKAGE_FETCH_FILE)
-	SWIFT_VERSION=$(VERSION) ./build-toolchain.sh $(PWD)/.fetch/swift-$(VERSION)-$(PLATFORM).tar.gz
+	SWIFT_VERSION=$(VERSION)			\
+	HOST_SWIFT_TOOLCHAIN=$(HOST_SWIFT_TOOLCHAIN)	\
+	TARGET_ARCH=$(ARCH)				\
+	TARGET_PLATFORM=$(PLATFORM)			\
+	HOST_X_LLD=$(HOST_X_LLD) \
+	INSTALL_PREFIX=$(INSTALL_PREFIX) \
+	./build-toolchain.sh $(PWD)/.fetch/swift-$(VERSION)-$(PLATFORM).tar.gz
 
 testbuild:
 	rm -rf my-test-app

--- a/ubuntu16.04/Makefile
+++ b/ubuntu16.04/Makefile
@@ -116,8 +116,6 @@ retrieve-packages:
 build-toolchain: $(PACKAGE_FETCH_FILE)
 	SWIFT_VERSION=$(VERSION)			\
 	HOST_SWIFT_TOOLCHAIN=$(HOST_SWIFT_TOOLCHAIN)	\
-	TARGET_ARCH=$(ARCH)				\
-	TARGET_PLATFORM=$(PLATFORM)			\
 	HOST_X_LLD=$(HOST_X_LLD) \
 	INSTALL_PREFIX=$(INSTALL_PREFIX) \
 	./build-toolchain.sh $(PWD)/.fetch/swift-$(VERSION)-$(PLATFORM).tar.gz

--- a/ubuntu16.04/build-toolchain.sh
+++ b/ubuntu16.04/build-toolchain.sh
@@ -26,8 +26,8 @@ SWIFT_LIB_DIR=${SWIFT_LIB_DIR:=/usr/local/lib/swift}
 # brew install swiftxcode/swiftxcode/swift-xctoolchain-5.3
 # brew install swiftxcode/swiftxcode/clang-llvm-bin-8
 # ./retrieve-sdk-packages.sh
-HOST_SWIFT_TOOLCHAIN=${SWIFT_LIB_DIR}/xctoolchains/${HOST_PLATFORM}-apple-darwin/${SWIFT_VERSION}-current/swift.xctoolchain
-HOST_X_LLD=${SWIFT_LIB_DIR}/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld
+HOST_SWIFT_TOOLCHAIN=${HOST_SWIFT_TOOLCHAIN:=${SWIFT_LIB_DIR}/xctoolchains/${HOST_PLATFORM}-apple-darwin/${SWIFT_VERSION}-current/swift.xctoolchain}
+HOST_X_LLD=${HOST_X_LLD:=${SWIFT_LIB_DIR}/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld}
 linux_sdk_name="${TARGET_ARCH}-${TARGET_PLATFORM}.sdk"
 LINUX_SDK="${BUILD_DIR}/${linux_sdk_name}"
 

--- a/ubuntu20.04/Makefile
+++ b/ubuntu20.04/Makefile
@@ -26,9 +26,15 @@ LINUX_TARGET_TRIPLE=$(ARCH)-linux-gnu
 PLATFORM=ubuntu20.04
 PACKAGE_URL=https://swift.org/builds/$(BRANCH)/$(subst .,,$(PLATFORM))/swift-$(VERSION)-$(SNAPSHOT)/swift-$(VERSION)-$(SNAPSHOT)-$(PLATFORM).tar.gz
 
+SWIFT_LIB_DIR=/usr/local/lib/swift
+HOST_SWIFT_TOOLCHAIN=/usr/local/lib/swift/xctoolchains/$(ARCH)-apple-darwin/$(HOST_VERSION)-current/swift.xctoolchain
+HOST_X_LLD=$(SWIFT_LIB_DIR)/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld
+
 BUILD_DIR=$(PWD)/.build
 FETCH_DIR=$(PWD)/.fetch
 PATCH_DIR=$(BUILD_DIR)/patch
+
+INSTALL_PREFIX=$(BUILD_DIR)
 
 DESTDIR_PREFIX=$(prefix)/lib/swift/dst/x86_64-unknown-linux/
 
@@ -106,7 +112,11 @@ retrieve-packages:
 # toolchain builder
 
 build-toolchain: $(PACKAGE_FETCH_FILE)
-	SWIFT_VERSION=$(MAIN_VERSION) ./build-toolchain.sh $(PWD)/.fetch/swift-$(VERSION)-$(PLATFORM).tar.gz
+	HOST_SWIFT_TOOLCHAIN=$(HOST_SWIFT_TOOLCHAIN) \
+	HOST_X_LLD=$(HOST_X_LLD) \
+	SWIFT_VERSION=$(MAIN_VERSION) \
+	INSTALL_PREFIX=$(INSTALL_PREFIX) \
+	./build-toolchain.sh $(PWD)/.fetch/swift-$(VERSION)-$(PLATFORM).tar.gz
 
 testbuild:
 	rm -rf my-test-app

--- a/ubuntu20.04/build-toolchain.sh
+++ b/ubuntu20.04/build-toolchain.sh
@@ -26,8 +26,10 @@ SWIFT_LIB_DIR=${SWIFT_LIB_DIR:=/usr/local/lib/swift}
 # brew install swiftxcode/swiftxcode/swift-xctoolchain-5.3
 # brew install swiftxcode/swiftxcode/clang-llvm-bin-8
 # ./retrieve-sdk-packages.sh
-HOST_SWIFT_TOOLCHAIN=${SWIFT_LIB_DIR}/xctoolchains/${HOST_PLATFORM}-apple-darwin/${SWIFT_VERSION}-current/swift.xctoolchain
-HOST_X_LLD=${SWIFT_LIB_DIR}/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld
+HOST_SWIFT_TOOLCHAIN=${HOST_SWIFT_TOOLCHAIN:=${SWIFT_LIB_DIR}/xctoolchains/${HOST_PLATFORM}-apple-darwin/${SWIFT_VERSION}-current/swift.xctoolchain}
+
+HOST_X_LLD=${HOST_X_LLD:=${SWIFT_LIB_DIR}/clang-llvm/${HOST_PLATFORM}-apple-darwin/8.0.0/bin/lld}
+  
 linux_sdk_name="${TARGET_ARCH}-${TARGET_PLATFORM}.sdk"
 LINUX_SDK="${BUILD_DIR}/${linux_sdk_name}"
 


### PR DESCRIPTION
Hi @helje5!

This pull request allows one to pass `HOST_SWIFT_TOOLCHAIN` and `HOST_X_LDD` to `make build-toolchain`, which will allow one to build cross-compilation toolchains when using a Homebrew installation that was placed in a different directory, `~` for example.

This also allows one to specify a custom `INSTALL_PREFIX`.

Jeff